### PR TITLE
Fix nightly unstable tests

### DIFF
--- a/.github/tools/lint_requirements.py
+++ b/.github/tools/lint_requirements.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+"""Sync .pre-commit-config.yaml dependencies with requirements.txt.
+
+The requirements file is necessary for running `pip install` outside of
+`pre-commit` hooks, like in CI jobs that run the other tools in this directory.
+`pre-commit` makes this rather annoying [0].
+
+[0]: https://github.com/pre-commit/pre-commit/issues/945
+"""
+
+import sys
+from pathlib import Path
+from typing import List, cast
+
+from ruamel.yaml import YAML
+
+PRECOMMIT_CONFIG_PATH = Path(".pre-commit-config.yaml")
+REQUIREMENTS_TXT_PATH = Path(".github/tools/requirements.txt")
+KNOWN_PYTHON_HOOKS = ["mypy"]
+
+
+def main() -> int:
+    with PRECOMMIT_CONFIG_PATH.open() as f:
+        config = YAML().load(f)
+
+    dependencies = None
+
+    for repo in config["repos"]:
+        for hook in repo["hooks"]:
+            if hook.get("language") == "python" or hook["id"] == KNOWN_PYTHON_HOOKS:
+                if dependencies is None:
+                    dependencies = cast(List[str], hook["additional_dependencies"])
+                elif (
+                    "additional_dependencies" in hook
+                    and hook["additional_dependencies"] != dependencies
+                ):
+                    print(
+                        "lint: error: .pre-commit-config.yaml python hooks have disagreeing additional_dependencies",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+    if not dependencies:
+        print(
+            "lint: error: .pre-commit-config is missing any hooks with python dependencies",
+            file=sys.stderr,
+        )
+        return 1
+
+    requirements_txt = "\n".join(dependencies) + "\n"
+
+    if REQUIREMENTS_TXT_PATH.read_text() != requirements_txt:
+        print(
+            "lint: error: requirements.txt does not match dependencies in .pre-commit-config.yaml",
+            file=sys.stderr,
+        )
+        REQUIREMENTS_TXT_PATH.write_text(requirements_txt)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/tools/requirements.txt
+++ b/.github/tools/requirements.txt
@@ -1,0 +1,4 @@
+colored==1.4.3
+dockerfile-parse==1.2.0
+ruamel.yaml==0.17.20
+types-requests==2.27.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
     branches: [main]
   pull_request:
 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Materialize version
+        default: unstable
+
   # Run against the latest unstable every night to catch problems before they
   # ship in a release.
   schedule:
@@ -26,18 +32,24 @@ jobs:
       - uses: KengoTODA/actions-setup-docker-compose@v1.0.4
         with:
           version: ${{ matrix.docker-compose }}
-      - run: .github/tools/bump.py materialize unstable
-        if: github.event.schedule
-      - run: |
+      - name: Bump Materialize
+        run: |
+          pip install -r .github/tools/requirements.txt
+          .github/tools/bump.py materialize ${{ github.events.inputs.version || 'unstable' }}
+        if: github.event.schedule || github.events.inputs.version
+      - name: Run and test demo
+        run: |
           cd ${{ matrix.demo }}
           $GITHUB_WORKSPACE/.github/tests/${{ matrix.demo }}.sh
-      - run: |
+      - name: Dump logs
+        run: |
           cd ${{ matrix.demo }}
           docker-compose logs > $GITHUB_WORKSPACE/docker-compose.log
         if: always()
-      - uses: actions/upload-artifact@v2
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
         with:
-          name: docker-compose.log
+          name: ${{ matrix.demo }}-docker-compose.log
           path: docker-compose.log
         if: always()
 
@@ -47,3 +59,18 @@ jobs:
       - uses: actions/checkout@v1
       - run: pip install pre-commit==2.16.0
       - run: pre-commit run --all-files
+
+  report:
+    runs-on: ubuntu-20.04
+    needs: [test, lint]
+    if: always()
+    steps:
+      - uses: actions-ecosystem/action-slack-notifier@v1
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          message: |
+            Demos failed against Materialize version "${{ github.events.inputs.version || 'unstable' }}".
+          channel: engineering
+          color: red
+          verbose: true
+        if: failure() && github.event.schedule

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,11 @@ repos:
     rev: v0.931
     hooks:
       - id: mypy
-        additional_dependencies:
+        additional_dependencies: &dependencies
           - colored==1.4.3
-          - types-requests==2.27.7
+          - dockerfile-parse==1.2.0
           - ruamel.yaml==0.17.20
+          - types-requests==2.27.7
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
@@ -36,12 +37,15 @@ repos:
       - id: shellcheck
   - repo: local
     hooks:
-      - id: local
-        name: local
+      - id: lint
+        name: Lint
         entry: .github/tools/lint.py
         language: python
-        files: (/(docker-)?compose.ya?ml$|Dockerfile)
-        additional_dependencies:
-          - colored==1.4.3
-          - dockerfile-parse==1.2.0
-          - ruamel.yaml==0.17.20
+        files: (/(docker-)?compose\.ya?ml$|/Dockerfile$)
+        additional_dependencies: *dependencies
+      - id: lint-requirements
+        name: Lint requirements
+        entry: .github/tools/lint_requirements.py
+        language: python
+        files: ^(\.pre-commit-config\.yaml|.github/tools/requirements\.txt)$
+        additional_dependencies: *dependencies


### PR DESCRIPTION
Running the version bump script in CI requires installing the various
pip dependencies outside of pre-commit, which is surprisingly annoying.