### PR TITLE
Update Slack channel to #eng-general

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,6 @@ jobs:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
             Demos failed against Materialize version "${{ github.event.inputs.version || 'unstable' }}".
-          channel: eng-general
+          channel: eng-notifications
           color: red
           verbose: true


### PR DESCRIPTION
The previous fix missed switching the channel name to `#eng-general`, so the report step is still failing with `channel_not_found`. Since DevEx will own the repo, should this actually point to `#devex` to avoid polluting the engineering channel?