### PR TITLE
ci/tests: Sleep for a little longer in `ecommerce-redpanda.sh`

### DIFF
--- a/.github/tests/ecommerce-redpanda.sh
+++ b/.github/tests/ecommerce-redpanda.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 # Turn on the demo and give it a few seconds to spin up.
 docker-compose up -d
-sleep 5
+sleep 15
 
 # Ensure that the items table is imported with the correct number of items.
 docker-compose run -T cli -c "


### PR DESCRIPTION
The `ecommerce-redpanda.sh` test seems to fails quite frequently due to the Schema Registry not being available. Bumping the 😴  from 5 to 15 seconds (same as `ecommerce.sh`).