### PR TITLE
ci: bump Black in pre-commit to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: fix-byte-order-marker
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
The most recent release of Click broke Black, which in turn is [breaking CI](https://github.com/MaterializeInc/demos/runs/5886985677?check_suite_focus=true) in this repo:

```bash
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo0bpitsi_/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repo0bpitsi_/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1372, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repo0bpitsi_/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1358, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repo0bpitsi_/py_env-python3/lib/python3.8/site-packages/click/__init__.py)
```

Bumping Black to 22.3.0 in `.pre-commit-config.yaml` should fix it, according to [this](https://github.com/psf/black/issues/2964#issuecomment-1080974737).