### PR TITLE
Debezium depends_on mysql

### DIFF
--- a/ecommerce-redpanda/compose.yaml
+++ b/ecommerce-redpanda/compose.yaml
@@ -55,6 +55,7 @@ services:
     healthcheck: {test: curl -f localhost:8083, interval: 1s, start_period: 120s}
     depends_on:
       redpanda: {condition: service_healthy}
+      mysql: {condition: service_healthy}
   debezium_deploy:
     image: debezium/connect:1.8
     depends_on:

--- a/ecommerce/compose.yaml
+++ b/ecommerce/compose.yaml
@@ -58,6 +58,7 @@ services:
     healthcheck: {test: curl -f localhost:8083, interval: 1s, start_period: 120s}
     depends_on:
       kafka: {condition: service_healthy}
+      mysql: {condition: service_healthy}
   debezium_deploy:
     image: debezium/connect:1.8
     depends_on:


### PR DESCRIPTION
Every once in a while, debezium starts up before MySQL and fails to connect to MySQL.

This fixes it by making debezium wait for the mysql healthcheck.