### PR TITLE
fix(antennas-postgres) to make it more suitable for quickstarts

### DIFF
--- a/.github/tests/antennas-postgres.sh
+++ b/.github/tests/antennas-postgres.sh
@@ -9,7 +9,7 @@ curl -fsSL http://stedolan.github.io/jq/download/linux64/jq > /usr/local/bin/jq
 chmod +x /usr/local/bin/jq
 
 # Turn on the demo and give it a few (good) seconds to spin up.
-docker-compose up -d
+AUTOSETUP=1 docker-compose up -d
 sleep 20
 
 # Run a SQL using the sql endpoint

--- a/antennas-postgres/README.md
+++ b/antennas-postgres/README.md
@@ -5,7 +5,7 @@ https://user-images.githubusercontent.com/11491779/166932582-e5a9fd47-e397-4419-
 If you want to try it right now, clone the project and run:
 
 ```bash
- # Run `export AUTOSETUP = 1` to run steps 2-3 automatically
+ # Run `AUTOSETUP=1 docker-compose up` to run steps 2-3 automatically
  docker-compose up
 ```
 
@@ -101,7 +101,7 @@ GRANT SELECT ON antennas, antennas_performance TO materialize;
 
 
   -- Create the Postgres Source
-  CREATE MATERIALIZED SOURCE IF NOT EXISTS antennas_publication_source
+  CREATE SOURCE IF NOT EXISTS antennas_publication_source
   FROM POSTGRES
   CONNECTION 'host=postgres port=5432 user=materialize password=materialize dbname=postgres'
   PUBLICATION 'antennas_publication_source';

--- a/antennas-postgres/README.md
+++ b/antennas-postgres/README.md
@@ -4,8 +4,9 @@ https://user-images.githubusercontent.com/11491779/166932582-e5a9fd47-e397-4419-
 
 If you want to try it right now, clone the project and run:
 
-```
-docker-compose up
+```bash
+ # Run `export AUTOSETUP = 1` to run steps 2-3 automatically
+ docker-compose up
 ```
 
 After a successful build:
@@ -107,7 +108,7 @@ GRANT SELECT ON antennas, antennas_performance TO materialize;
 
 
   -- Turn the Postgres tables into Materialized Views
-  CREATE MATERIALIZED VIEWS FROM SOURCE antennas_publication_source;
+  CREATE VIEWS FROM SOURCE antennas_publication_source;
 
 
   -- Filter last half minute updates and aggregate by anntena ID and GeoJSON to obtain the average performance in the last half minute.

--- a/antennas-postgres/backend/src/app.ts
+++ b/antennas-postgres/backend/src/app.ts
@@ -172,6 +172,7 @@ async function* antennasUpdates(_, ctxVars) {
       .finally(() => {
         console.log('Finished tail.');
         done = true;
+        resolve([]);
       });
 
     connectionEventEmitter.on('disconnect', (unsubscriptionId) => {

--- a/antennas-postgres/compose.yaml
+++ b/antennas-postgres/compose.yaml
@@ -35,6 +35,8 @@ services:
     container_name: helper
     build:
       context: ./helper
+    environment:
+      - AUTOSETUP=${AUTOSETUP}
     init: true
     depends_on:
       - materialized

--- a/antennas-postgres/helper/src/app.ts
+++ b/antennas-postgres/helper/src/app.ts
@@ -15,7 +15,7 @@ async function setUpMaterialize() {
   const poolClient = await pool.connect();
 
   await poolClient.query(`
-    CREATE MATERIALIZED SOURCE IF NOT EXISTS antennas_publication_source
+    CREATE SOURCE IF NOT EXISTS antennas_publication_source
     FROM POSTGRES
     CONNECTION 'host=postgres port=5432 user=materialize password=materialize dbname=postgres'
     PUBLICATION 'antennas_publication_source';

--- a/antennas-postgres/helper/src/app.ts
+++ b/antennas-postgres/helper/src/app.ts
@@ -27,7 +27,7 @@ async function setUpMaterialize() {
 
   if (!rowCount) {
     await poolClient.query(`
-    CREATE MATERIALIZED VIEWS FROM SOURCE antennas_publication_source;
+    CREATE VIEWS FROM SOURCE antennas_publication_source;
   `);
 
     await poolClient.query(`
@@ -76,11 +76,21 @@ async function dataGenerator() {
   }, 1000);
 }
 
-setUpMaterialize()
-  .then(() => {
-    console.log('Generating data.');
-    dataGenerator();
-  })
-  .catch((err) => {
-    console.error(err);
-  });
+const {AUTOSETUP} = process.env;
+
+/**
+ * If AUTOSETUP = true then run automatically the source creation, etc..
+ */
+if (AUTOSETUP) {
+  setUpMaterialize()
+    .then(() => {
+      console.log('Generating data.');
+      dataGenerator();
+    })
+    .catch((err) => {
+      console.error(err);
+    });
+} else {
+  console.log('Generating data.');
+  dataGenerator();
+}

--- a/antennas-postgres/microservice/src/app.ts
+++ b/antennas-postgres/microservice/src/app.ts
@@ -156,19 +156,31 @@ const antennasPerformanceListener = (data) => {
 
 const onError = (err) => {
   console.error('Ouch. Some error: ', err);
+
+  setTimeout(() => {
+    subscribe();
+  }, 10000);
 };
 
 const onComplete = () => {
   console.log('Finished.');
+
+  setTimeout(() => {
+    subscribe();
+  }, 10000);
 };
 
-graphqlClient.subscribe(
-  {
-    query: 'subscription { antennasUpdates { antenna_id, geojson, performance } }',
-  },
-  {
-    next: antennasPerformanceListener,
-    error: onError,
-    complete: onComplete,
-  }
-);
+const subscribe = () => {
+  graphqlClient.subscribe(
+    {
+      query: 'subscription { antennasUpdates { antenna_id, geojson, performance } }',
+    },
+    {
+      next: antennasPerformanceListener,
+      error: onError,
+      complete: onComplete,
+    }
+  );
+};
+
+subscribe();


### PR DESCRIPTION
Refactor the code to be more suitable for the documentation quickstart. The user should be able to run all the code that Materialize needs to consume from Postgres.