### PR TITLE
cp-kafka: bump to 7.2.0

### DIFF
--- a/.github/tools/images.yml
+++ b/.github/tools/images.yml
@@ -37,10 +37,10 @@ buildpack:
   images:
     - buildpack-deps
 confluent:
-  tag: 7.0.1
+  tag: 7.2.0
   images:
     - confluentinc/cp-zookeeper
-    - confluentinc/cp-enterprise-kafka
+    - confluentinc/cp-kafka
     - confluentinc/cp-schema-registry
 metabase:
   tag: v0.41.5

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We recommend running Docker with at least **2 CPUs** and **8GB** of memory, so d
     </thead>
     <tbody>
         <tr>
-          <td><b><code><a href="https://github.com/MaterializeInc/demos/tree/main/antennas-kafka">antennas-kafka</a> ✋</code></b></td>
+          <td><b><code><a href="https://github.com/MaterializeInc/demos/tree/main/antennas-kafka">antennas-kafka</a></code></b></td>
             <td>Node.js, GraphQL, Kafka</td>
             <td rowspan=2>Tracking key performance indicators for infrastructure monitoring</td>
         </tr>

--- a/antennas-kafka/compose.yaml
+++ b/antennas-kafka/compose.yaml
@@ -1,13 +1,13 @@
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.2.0
     container_name: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:7.0.1
+    image: confluentinc/cp-kafka:7.2.0
     container_name: broker
     ports:
       # To learn about configuring Kafka for access across networks see

--- a/antennas-postgres/postgres/Dockerfile
+++ b/antennas-postgres/postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:14.2-alpine
 
-# Automatically runned by Postgres
+# Automatically run by Postgres
 COPY ./create.sh /docker-entrypoint-initdb.d/
 COPY ./seed.sh /docker-entrypoint-initdb.d/
 

--- a/billing/compose.yaml
+++ b/billing/compose.yaml
@@ -9,14 +9,14 @@ services:
     healthcheck: {test: curl -f localhost:6875, interval: 1s, start_period: 30s}
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.2.0
     init: true
     environment:
       - ZOOKEEPER_CLIENT_PORT=2181
     healthcheck: {test: nc -z localhost 2181, interval: 1s, start_period: 120s}
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:7.0.1
+    image: confluentinc/cp-kafka:7.2.0
     init: true
     ports: [9092]
     environment:
@@ -31,7 +31,7 @@ services:
     healthcheck: {test: nc -z localhost 9092, interval: 1s, start_period: 120s}
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.0.1
+    image: confluentinc/cp-schema-registry:7.2.0
     init: true
     ports: [8081]
     environment:

--- a/chbench/compose.yaml
+++ b/chbench/compose.yaml
@@ -22,13 +22,13 @@ services:
     healthcheck: {test: mysql -prootpw -e 'select 1', interval: 1s, start_period: 60s}
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.2.0
     environment:
       - ZOOKEEPER_CLIENT_PORT=2181
     healthcheck: {test: nc -z localhost 2181, interval: 1s, start_period: 120s}
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:7.0.1
+    image: confluentinc/cp-kafka:7.2.0
     environment:
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
@@ -42,7 +42,7 @@ services:
     healthcheck: {test: nc -z localhost 9092, interval: 1s, start_period: 120s}
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.0.1
+    image: confluentinc/cp-schema-registry:7.2.0
     init: true
     environment:
       - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092

--- a/ecommerce/compose.yaml
+++ b/ecommerce/compose.yaml
@@ -17,12 +17,12 @@ services:
       - ${PWD}/mysql/mysql_bootstrap.sql:/docker-entrypoint-initdb.d/mysql_bootstrap.sql
     healthcheck: {test: mysql -pdebezium -e 'select 1', interval: 1s, start_period: 60s}
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.2.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     healthcheck: {test: nc -z localhost 2181, interval: 1s, start_period: 120s}
   kafka:
-    image: confluentinc/cp-enterprise-kafka:7.0.1
+    image: confluentinc/cp-kafka:7.2.0
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
@@ -35,7 +35,7 @@ services:
       zookeeper: {condition: service_healthy}
     healthcheck: {test: nc -z localhost 9092, interval: 1s, start_period: 120s}
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.0.1
+    image: confluentinc/cp-schema-registry:7.2.0
     environment:
       - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry

--- a/feature-store/compose.yaml
+++ b/feature-store/compose.yaml
@@ -30,8 +30,8 @@ services:
     environment:
       - POSTGRES_DB=default
       - POSTGRES_HOST_AUTH_METHOD=trust
-    healthcheck: {test: pg_isready -q -d postgres -U postgres, interval: 5s, timeout: 60s,
-      start_period: 10s}
+    healthcheck:
+      {test: pg_isready -q -d postgres -U postgres, interval: 5s, timeout: 60s, start_period: 10s}
     command: -c wal_level=logical
     ports:
       - 5433:5432


### PR DESCRIPTION
Switches the base Kafka image from `cp-enterprise-kafka` to the lighter `cp-kafka`, and bumps the version to 7.2.0. Though the Confluent-provided images are now multi-arch 🎉 , there are still two dependencies keeping our demos from running smoothly on ARM:

* **Debezium:** assuming `debezium/connect` will be updated to use the new Kafka images soon, this shouldn't be an issue for much longer. We could (and maybe should) use the base `cp-connect` image and install the minimum required connectors to keep things lighter, though.
* **Metabase:** ARM-support isn't there yet (see [#13119](https://github.com/metabase/metabase/issues/13119)). There are some multi-arch images in the wild (like [`scurrilous/metabase`](https://hub.docker.com/r/scurrilous/metabase) or [`iwalucas/metabase`](https://hub.docker.com/r/iwalucas/metabase)), but relying on non-official images isn't ideal.