### PR TITLE
Update Redpanda demo for Materialize cloud

### DIFF
--- a/ecommerce-redpanda/.env.example
+++ b/ecommerce-redpanda/.env.example
@@ -1,0 +1,2 @@
+# Local MySQL instace details
+MYSQL_PASSWORD=I957DO9cYXp6JDEv

--- a/ecommerce-redpanda/compose.yaml
+++ b/ecommerce-redpanda/compose.yaml
@@ -1,21 +1,16 @@
 services:
-  materialized:
-    image: materialize/materialized:v0.26.4
-    ports:
-      - 6875:6875
-    healthcheck: {test: curl -f localhost:6875, interval: 1s, start_period: 30s}
   mysql:
     image: mysql/mysql-server:8.0.27
     ports:
       - 3306:3306
     environment:
-      - MYSQL_ROOT_PASSWORD=debezium
+      - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_USER=mysqluser
-      - MYSQL_PASSWORD=mysqlpw
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
     volumes:
       - ../ecommerce/mysql/mysql.cnf:/etc/mysql/conf.d
       - ../ecommerce/mysql/mysql_bootstrap.sql:/docker-entrypoint-initdb.d/mysql_bootstrap.sql
-    healthcheck: {test: mysql -pdebezium -e 'select 1', interval: 1s, start_period: 60s}
+    healthcheck: {test: mysql -p$$MYSQL_PASSWORD -e 'select 1', interval: 1s, start_period: 60s}
   redpanda:
     image: docker.vectorized.io/vectorized/redpanda:v21.11.2
     command:
@@ -27,9 +22,9 @@ services:
       - --node-id 0
       - --check=false
       - --kafka-addr 0.0.0.0:9092
-      - --advertise-kafka-addr redpanda:9092
+      - --advertise-kafka-addr ${EXTERNAL_IP:-redpanda}:9092
       - --pandaproxy-addr 0.0.0.0:8082
-      - --advertise-pandaproxy-addr redpanda:8082
+      - --advertise-pandaproxy-addr ${EXTERNAL_IP:-redpanda}:8082
       - --set redpanda.enable_transactions=true
       - --set redpanda.enable_idempotence=true
     ports:
@@ -38,9 +33,9 @@ services:
       - 8082:8082
     healthcheck: {test: curl -f localhost:9644/v1/status/ready, interval: 1s, start_period: 30s}
   debezium:
-    image: debezium/connect:1.8
+    image: debezium/connect:1.9
     environment:
-      BOOTSTRAP_SERVERS: redpanda:9092
+      BOOTSTRAP_SERVERS: ${EXTERNAL_IP:-redpanda}:9092
       GROUP_ID: 1
       CONFIG_STORAGE_TOPIC: connect_configs
       OFFSET_STORAGE_TOPIC: connect_offsets
@@ -57,27 +52,27 @@ services:
       redpanda: {condition: service_healthy}
       mysql: {condition: service_healthy}
   debezium_deploy:
-    image: debezium/connect:1.8
+    image: debezium/connect:1.9
     depends_on:
       debezium: {condition: service_healthy}
     environment:
-      KAFKA_ADDR: redpanda:9092
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - KAFKA_ADDR=${EXTERNAL_IP:-redpanda}:9092
     volumes:
-      - ../ecommerce/mysql/mysql_dbz.sh:/mysql_dbz.sh
+      - ./mysql/mysql_dbz.sh:/mysql_dbz.sh
     entrypoint: [bash, -c, /mysql_dbz.sh]
-  metabase:
-    image: metabase/metabase:v0.41.5
-    depends_on: [materialized]
-    ports:
-      - 3030:3000
+  # metabase:
+  #   image: metabase/metabase:v0.41.5
+  #   ports:
+  #     - 3030:3000
   loadgen:
     build: ../ecommerce/loadgen
     init: true
     environment:
-      KAFKA_ADDR: redpanda:9092
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - KAFKA_ADDR=${EXTERNAL_IP:-redpanda}:9092
+      - CONFLUENT_BROKER_HOST=${EXTERNAL_IP:-redpanda}:9092
     depends_on:
       mysql: {condition: service_healthy}
       debezium: {condition: service_healthy}
       redpanda: {condition: service_healthy}
-  cli:
-    image: materialize/cli:v0.26.4

--- a/ecommerce-redpanda/compose.yaml
+++ b/ecommerce-redpanda/compose.yaml
@@ -61,10 +61,10 @@ services:
     volumes:
       - ./mysql/mysql_dbz.sh:/mysql_dbz.sh
     entrypoint: [bash, -c, /mysql_dbz.sh]
-  # metabase:
-  #   image: metabase/metabase:v0.41.5
-  #   ports:
-  #     - 3030:3000
+  metabase:
+    image: metabase/metabase:v0.41.5
+    ports:
+      - 3030:3000
   loadgen:
     build: ../ecommerce/loadgen
     init: true

--- a/ecommerce-redpanda/mysql/mysql_dbz.sh
+++ b/ecommerce-redpanda/mysql/mysql_dbz.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+echo "Deploying Debezium MySQL connector"
+
+curl -s -X PUT -H  "Content-Type:application/json" http://debezium:8083/connectors/register-mysql/config \
+    -d '{
+    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+    "database.hostname": "mysql",
+    "database.port": 3306,
+    "database.user": "debezium",
+    "database.password": "'"${MYSQL_PASSWORD}"'",
+    "database.server.name": "mysql",
+    "database.server.id": "223344",
+    "database.allowPublicKeyRetrieval": true,
+    "database.history.kafka.bootstrap.servers":"'"$KAFKA_ADDR"'",
+    "database.history.kafka.topic": "mysql-history",
+    "database.include.list": "shop",
+    "time.precision.mode": "connect",
+    "include.schema.changes": false
+ }'

--- a/ecommerce/loadgen/generate_load.py
+++ b/ecommerce/loadgen/generate_load.py
@@ -39,17 +39,16 @@ if os.getenv("CONFLUENT_API_KEY") and os.getenv("CONFLUENT_API_SECRET"):
     producer = KafkaProducer(
         bootstrap_servers=[kafkaHostPort],
         value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+        security_protocol='SASL_SSL',
+        sasl_mechanism='PLAIN',
+        sasl_plain_username=os.getenv("CONFLUENT_API_KEY"),
+        sasl_plain_password=os.getenv("CONFLUENT_API_SECRET")
     )
 else:
     producer = KafkaProducer(
         bootstrap_servers=[kafkaHostPort],
         value_serializer=lambda x: json.dumps(x).encode("utf-8"),
-        security_protocol='SASL_SSL',
-        sasl_mechanism='PLAIN',
-        sasl_plain_username=os.getenv("CONFLUENT_API_KEY", ""),
-        sasl_plain_password=os.getenv("CONFLUENT_API_SECRET", "")
     )
-
 def generatePageview(viewer_id, target_id, page_type):
     return {
         "user_id": viewer_id,

--- a/ecommerce/loadgen/generate_load.py
+++ b/ecommerce/loadgen/generate_load.py
@@ -35,7 +35,7 @@ purchase_insert = "INSERT INTO shop.purchases (user_id, item_id, quantity, purch
 
 
 # Initialize Kafka
-if os.getenv("CONFLUENT_API_KEY", "") == "" or os.getenv("CONFLUENT_API_SECRET", "") == "":
+if os.getenv("CONFLUENT_API_KEY") and os.getenv("CONFLUENT_API_SECRET"):
     producer = KafkaProducer(
         bootstrap_servers=[kafkaHostPort],
         value_serializer=lambda x: json.dumps(x).encode("utf-8"),

--- a/ecommerce/loadgen/generate_load.py
+++ b/ecommerce/loadgen/generate_load.py
@@ -31,19 +31,24 @@ categories = ["widgets", "gadgets", "doodads", "clearance"]
 # INSERT TEMPLATES
 item_insert = "INSERT INTO shop.items (name, category, price, inventory) VALUES ( %s, %s, %s, %s )"
 user_insert = "INSERT INTO shop.users (email, is_vip) VALUES ( %s, %s )"
-purchase_insert = "INSERT INTO shop.purchases (user_id, item_id, quantity, purchase_price, status) VALUES ( %s, %s, %s, %s )"
+purchase_insert = "INSERT INTO shop.purchases (user_id, item_id, quantity, purchase_price, status) VALUES ( %s, %s, %s, %s, %s )"
 
 
 # Initialize Kafka
-producer = KafkaProducer(
-    bootstrap_servers=[kafkaHostPort],
-    value_serializer=lambda x: json.dumps(x).encode("utf-8"),
-    security_protocol='SASL_SSL',
-    sasl_mechanism='PLAIN',
-    sasl_plain_username=os.getenv("CONFLUENT_API_KEY", ""),
-    sasl_plain_password=os.getenv("CONFLUENT_API_SECRET", "")
-)
-
+if os.getenv("CONFLUENT_API_KEY", "") == "" or os.getenv("CONFLUENT_API_SECRET", "") == "":
+    producer = KafkaProducer(
+        bootstrap_servers=[kafkaHostPort],
+        value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+    )
+else:
+    producer = KafkaProducer(
+        bootstrap_servers=[kafkaHostPort],
+        value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+        security_protocol='SASL_SSL',
+        sasl_mechanism='PLAIN',
+        sasl_plain_username=os.getenv("CONFLUENT_API_KEY", ""),
+        sasl_plain_password=os.getenv("CONFLUENT_API_SECRET", "")
+    )
 
 def generatePageview(viewer_id, target_id, page_type):
     return {


### PR DESCRIPTION
Updating the ecommerce-redpanda demo to work with Materialize Cloud.

This will work if you clone the repo on a publicly accessible VM like an EC2 instance and use the EC2 IP address to create your Kafka connection objects similar to what we did for the antennas postgres demo.