### PR TITLE
dbt-get-started: force dependency on parent source model

### DIFF
--- a/dbt-get-started/models/staging/on_time_bids.sql
+++ b/dbt-get-started/models/staging/on_time_bids.sql
@@ -1,3 +1,5 @@
+-- depends_on: {{ ref('auction_house') }}
+
 {{ config(materialized='view') }}
 
 SELECT


### PR DESCRIPTION
See Materialize #17241 for context.