### PR TITLE
Add ec2 ssh bastion terraform demo

### DIFF
--- a/integrations/terraform/README.md
+++ b/integrations/terraform/README.md
@@ -9,6 +9,7 @@ This is a collection of demos that show how to use the [Materialize Terraform pr
 | Demo                               | Description                                                             |
 | ---------------------------------- | ----------------------------------------------------------------------- |
 | [MSK PrivateLink](msk-privatelink) | Create an AWS PrivateLink connection between Materialize and Amazon MSK |
+| [EC2 SSH Bastion](ec2-ssh-bastion) | Create an EC2 instance that can be used as an SSH bastion              |
 
 ## Prerequisites
 

--- a/integrations/terraform/ec2-ssh-bastion/.gitignore
+++ b/integrations/terraform/ec2-ssh-bastion/.gitignore
@@ -1,0 +1,36 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+locals.tf
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+.terraform.lock.hcl

--- a/integrations/terraform/ec2-ssh-bastion/README.md
+++ b/integrations/terraform/ec2-ssh-bastion/README.md
@@ -1,0 +1,131 @@
+# Materialize Terraform Provider + Materialize Module for EC2 SSH Bastion
+
+This is an example of how to use the [Materialize Terraform Provider](https://github.com/MaterializeInc/terraform-provider-materialize) to manage your Materialize resources like [connections](https://materialize.com/docs/sql/create-connection/), [sources](https://materialize.com/docs/sql/create-source/), and [clusters](https://materialize.com/docs/sql/create-cluster/) alongside the [Materialize Module EC2 SSH Bastion](https://github.com/MaterializeInc/terraform-aws-ec2-ssh-bastion).
+
+The end result is an EC2 SSH Bastion host in your AWS account and an SSH connection in Materialize that you can use to connect to your sources.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
+- [Materialize Cloud](https://cloud.materialize.com/) account
+- [AWS](https://aws.amazon.com/) account
+
+## Overview of the Terraform Configuration
+
+The configuration is divided into several sections:
+
+1.  **Define the Materialize provider**
+2.  **Include the AWS provider**
+3.  **Include the Materialize provider**
+4.  **Use the Materialize EC2 SSH Bastion module**
+
+<!-- TODO add a diagram -->
+
+## Step-by-step Instructions
+
+### Step 1: Define the Materialize provider
+
+This block specifies the required version of the Materialize provider and its source:
+
+```hcl
+terraform {
+  required_providers {
+    materialize = {
+      source = "MaterializeInc/materialize"
+      version = "0.0.4"
+    }
+  }
+}
+```
+
+### Step 2: Include the AWS provider
+
+Configure the AWS provider with the specified region:
+
+```hcl
+provider "aws" {
+    region = "us-east-1"
+}
+```
+
+### Step 3: Include the Materialize provider
+
+Configure the Materialize provider with the necessary connection information:
+
+```hcl
+provider "materialize" {
+  host     = local.materialize_host
+  username = local.materialize_username
+  password = local.materialize_password
+  port     = 6875
+  database = "materialize"
+}
+```
+
+
+### Step 4: Use the Materialize EC2 SSH Bastion module
+
+Use the Materialize EC2 SSH Bastion module to create an EC2 instance that can be used to create an SSH connection in Materialize:
+
+```hcl
+module "ssh_bastion" {
+  source  = "MaterializeInc/ec2-ssh-bastion/aws"
+  version = "0.1.0"
+
+  aws_region     = local.aws_region
+  mz_egress_ips  = local.mz_egress_ips
+  vpc_id         = local.vpc_id
+  subnet_id      = local.subnet_id
+  ssh_public_key = local.ssh_public_key
+}
+```
+
+Define the following variables in your `locals.tf` file:
+
+```hcl
+locals {
+  aws_region     = "us-east-1"
+  mz_egress_ips  = ["1.2.3.4/32", "4.3.2.1/32"]
+  vpc_id         = "vpc-1234567890"
+  subnet_id      = "subnet-1234567890"
+  ssh_public_key = "ssh-rsa AAAAB..."
+}
+```
+
+### Step 5: Create an SSH connection in Materialize
+
+Create an SSH connection in Materialize using the `materialize_connection` resource:
+
+```hcl
+resource "materialize_connection_ssh_tunnel" "example_ssh_connection" {
+  name        = "ssh_example_connection"
+  schema_name = "public"
+  host        = module.ssh_bastion.ssh_bastion_server.public_ip
+  port        = 22
+  user        = "ubuntu"
+}
+```
+
+Then to get the public SSH key of the connection, you can use the following output:
+
+```hcl
+output "example" {
+  value       = materialize_connection_ssh_tunnel.example_ssh_connection
+}
+```
+
+### Step 6: Upload the Materialize SSH key to the EC2 instance
+
+To upload the Materialize SSH key to the EC2 instance, you can get the public key of the connection and then use it to upload the key to the EC2 instance.
+
+You can use the following output to get the command that you need to run:
+
+```hcl
+output "upload_ssh_key" {
+  value = "To upload the SSH key to the EC2 bastion server run the following command: \n\n ssh -i ${local.ssh_private_key} ubuntu@${module.ssh_bastion.ssh_bastion_server.public_ip} 'echo ${materialize_connection_ssh_tunnel.example_ssh_connection.public_key_1} >> ~/.ssh/authorized_keys'"
+}
+```
+
+## Complete Example
+
+Check out the [`main.tf`](main.tf) file in this repository for a complete example of how to use the Materialize Terraform Provider and the Materialize EC2 SSH Bastion Terraform Module.

--- a/integrations/terraform/ec2-ssh-bastion/README.md
+++ b/integrations/terraform/ec2-ssh-bastion/README.md
@@ -73,15 +73,19 @@ provider "materialize" {
 Use the Materialize EC2 SSH Bastion module to create an EC2 instance that can be used to create an SSH connection in Materialize:
 
 ```hcl
+# Get the Materialize egress IPs
+data "materialize_egress_ips" "all" {}
+
+# Create the EC2 SSH Bastion
 module "ssh_bastion" {
   source  = "MaterializeInc/ec2-ssh-bastion/aws"
   version = "0.1.0"
 
   aws_region     = local.aws_region
-  mz_egress_ips  = local.mz_egress_ips
   vpc_id         = local.vpc_id
   subnet_id      = local.subnet_id
   ssh_public_key = local.ssh_public_key
+  mz_egress_ips  = [for ip in data.materialize_egress_ips.all.egress_ips : "${ip}/32"]
 }
 ```
 
@@ -90,7 +94,6 @@ Define the following variables in your `locals.tf` file:
 ```hcl
 locals {
   aws_region     = "us-east-1"
-  mz_egress_ips  = ["1.2.3.4/32", "4.3.2.1/32"]
   vpc_id         = "vpc-1234567890"
   subnet_id      = "subnet-1234567890"
   ssh_public_key = "ssh-rsa AAAAB..."

--- a/integrations/terraform/ec2-ssh-bastion/README.md
+++ b/integrations/terraform/ec2-ssh-bastion/README.md
@@ -10,16 +10,21 @@ The end result is an EC2 SSH Bastion host in your AWS account and an SSH connect
 - [Materialize Cloud](https://cloud.materialize.com/) account
 - [AWS](https://aws.amazon.com/) account
 
-## Overview of the Terraform Configuration
+## Overview
 
-The configuration is divided into several sections:
+![Terraform Configuration](https://github.com/MaterializeInc/demos/assets/21223421/ff6d7317-b74d-4271-8107-433514e81b69)
 
-1.  **Define the Materialize provider**
-2.  **Include the AWS provider**
-3.  **Include the Materialize provider**
-4.  **Use the Materialize EC2 SSH Bastion module**
+The Terraform configuration creates the following resources:
 
-<!-- TODO add a diagram -->
+- In AWS:
+  - An EC2 SSH Bastion host
+  - Security group for EC2 instance
+  - SSH key pair
+
+- In Materialize:
+  - An [SSH connection](https://materialize.com/docs/connect-sources/network-security/ssh-tunnel) to the EC2 SSH Bastion host
+
+The SSH connection in Materialize can later be used to create secure [connections](https://materialize.com/docs/sql/create-connection/) from Materialize to Postgres databases, Kafka clusters, or Confluent Schema Registries.
 
 ## Step-by-step Instructions
 

--- a/integrations/terraform/ec2-ssh-bastion/main.tf
+++ b/integrations/terraform/ec2-ssh-bastion/main.tf
@@ -69,5 +69,5 @@ output "ssh_connection_details" {
 
 # Output instructions on how to upload the ssh key
 output "upload_ssh_key" {
-  value = "To upload the SSH key to the EC2 bastion server run the following command: \n\n ssh -i ${local.ssh_private_key} ubuntu@${module.ssh_bastion.ssh_bastion_server.public_ip} 'echo ${materialize_connection_ssh_tunnel.example_ssh_connection.public_key_1} >> ~/.ssh/authorized_keys'"
+  value = "# To upload the SSH key to the EC2 bastion server run the following command: \n\n ssh -i ${local.ssh_private_key} ubuntu@${module.ssh_bastion.ssh_bastion_server.public_ip} 'echo ${materialize_connection_ssh_tunnel.example_ssh_connection.public_key_1} >> ~/.ssh/authorized_keys'"
 }

--- a/integrations/terraform/ec2-ssh-bastion/main.tf
+++ b/integrations/terraform/ec2-ssh-bastion/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     materialize = {
       source  = "MaterializeInc/materialize"
-      version = "0.0.4"
+      version = "0.0.7"
     }
     # null = {
     #   source = "hashicorp/null"
@@ -26,16 +26,19 @@ provider "materialize" {
   database = "materialize"
 }
 
+# Get the Materialize egress IPs
+data "materialize_egress_ips" "all" {}
+
 # Use the materialize ssh module
 module "ssh_bastion" {
   source  = "MaterializeInc/ec2-ssh-bastion/aws"
   version = "0.1.0"
 
   aws_region     = local.aws_region
-  mz_egress_ips  = local.mz_egress_ips
   vpc_id         = local.vpc_id
   subnet_id      = local.subnet_id
   ssh_public_key = local.ssh_public_key
+  mz_egress_ips  = [for ip in data.materialize_egress_ips.all.egress_ips : "${ip}/32"]
 }
 
 # Create an SSH connection in Materialize

--- a/integrations/terraform/ec2-ssh-bastion/main.tf
+++ b/integrations/terraform/ec2-ssh-bastion/main.tf
@@ -1,0 +1,73 @@
+# Define the Materialize provider
+terraform {
+  required_providers {
+    materialize = {
+      source  = "MaterializeInc/materialize"
+      version = "0.0.4"
+    }
+    # null = {
+    #   source = "hashicorp/null"
+    #   version = "3.2.1"
+    # }
+  }
+}
+
+# Include aws provider
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Include Materialize provider
+provider "materialize" {
+  host     = local.materialize_host
+  username = local.materialize_username
+  password = local.materialize_password
+  port     = 6875
+  database = "materialize"
+}
+
+# Use the materialize ssh module
+module "ssh_bastion" {
+  source  = "MaterializeInc/ec2-ssh-bastion/aws"
+  version = "0.1.0"
+
+  aws_region     = local.aws_region
+  mz_egress_ips  = local.mz_egress_ips
+  vpc_id         = local.vpc_id
+  subnet_id      = local.subnet_id
+  ssh_public_key = local.ssh_public_key
+}
+
+# Create an SSH connection in Materialize
+resource "materialize_connection_ssh_tunnel" "example_ssh_connection" {
+  name        = "ssh_example_connection"
+  schema_name = "public"
+  host        = module.ssh_bastion.ssh_bastion_server.public_ip
+  port        = 22
+  user        = "ubuntu"
+}
+
+# Upload the example_ssh_connection.public_key_1 to the EC2 ssh bastion server
+# resource "null_resource" "upload_ssh_key" {
+#     provisioner "remote-exec" {
+#     connection {
+#       host = module.ssh_bastion.ssh_bastion_server.public_ip
+#       user = "ubuntu"
+#       private_key = file("${local.ssh_private_key}")
+#     }
+
+#     inline = ["echo 'connected!'"]
+#   }
+#   provisioner "local-exec" {
+#     command = "ssh -i ${local.ssh_private_key} ubuntu@${module.ssh_bastion.ssh_bastion_server.public_ip} 'echo ${materialize_connection_ssh_tunnel.example_ssh_connection.public_key_1} >> ~/.ssh/authorized_keys'"
+#   }
+# }
+
+output "ssh_connection_details" {
+  value = materialize_connection_ssh_tunnel.example_ssh_connection
+}
+
+# Output instructions on how to upload the ssh key
+output "upload_ssh_key" {
+  value = "To upload the SSH key to the EC2 bastion server run the following command: \n\n ssh -i ${local.ssh_private_key} ubuntu@${module.ssh_bastion.ssh_bastion_server.public_ip} 'echo ${materialize_connection_ssh_tunnel.example_ssh_connection.public_key_1} >> ~/.ssh/authorized_keys'"
+}


### PR DESCRIPTION
Similar to the MSK PrivateLink Terraform demo, adding an ec2 SSH bastion host example as well

![Terraform Configuration](https://github.com/MaterializeInc/demos/assets/21223421/ff6d7317-b74d-4271-8107-433514e81b69)
