### PR TITLE
integrations: increase interval in storage query to reduce workload

### DIFF
--- a/integrations/datadog/README.md
+++ b/integrations/datadog/README.md
@@ -26,7 +26,7 @@ This demo shows how to make Materialize metadata available as key metrics for mo
     cd integrations/datadog
     ```
 
-2. Edit the `config.yaml` file and set your Materialize details under the `connections` key:
+2. Edit the `config.yaml` file and set your Materialize details under the two available `connections` keys:
 
     ```yaml
     connections:

--- a/integrations/datadog/config.yaml
+++ b/integrations/datadog/config.yaml
@@ -23,7 +23,7 @@ jobs:
       - "replica_status"
     query:  |
             SELECT
-              U.replica_id,
+              DISTINCT(U.replica_id),
               R.cluster_id,
               C.name as cluster_name,
               R.name as replica_name,
@@ -130,9 +130,9 @@ jobs:
               GROUP BY object_id
             )
             SELECT
+              DISTINCT(id) as object_id,
               name as object_name,
               type as object_type,
-              id as object_id,
               size_bytes
             FROM mz_storage_usage U, mz_objects O, last_measure L
             WHERE O.id = U.object_id

--- a/integrations/datadog/config.yaml
+++ b/integrations/datadog/config.yaml
@@ -3,6 +3,7 @@ jobs:
 - name: "materialize"
   interval: '1m'
   connections:
+  # There is a second connection needed to be configured at the bottom of the file
   - "postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/materialize?options=--cluster%3Dmz_introspection"
   queries:
   - name: "cluster_replica_usage"
@@ -107,6 +108,11 @@ jobs:
             JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
             JOIN mz_internal.mz_source_statuses ST ON (S.id = ST.id)
             GROUP BY S.name, S.type, S.cluster_id, cluster_name, source_status_label, source_status_counter, snapshot_committed;
+- name: "materialize"
+  interval: '1h'
+  connections:
+  - "postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/materialize?options=--cluster%3Dmz_introspection"
+  queries:
   - name: "storage_usage"
     help: "Storage usage"
     labels:


### PR DESCRIPTION
This PR applies a different interval for the `storage_usage` metric. It is a very expensive one and only updates every one hour. I increased the interval to reduce the `mz_introspection` usage.