### PR TITLE
integrations: grafana dashboard queries + templates

### DIFF
--- a/integrations/prometheus-sql-exporter/config.yml.example
+++ b/integrations/prometheus-sql-exporter/config.yml.example
@@ -1,243 +1,127 @@
 ---
 jobs:
-- name: "global"
+- name: "materialize"
   interval: '1m'
   connections:
-  - "postgres://YOUR_MATERIALIZE_USER:YOUR_MATERIALIZE_PASSWORD@YOUR_MATERIALIZE_HOST.materialize.cloud:6875/materialize?options=--cluster%3Dmz_introspection"
+  # There is a second connection needed to be configured at the bottom of the file
+  - "postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/materialize?options=--cluster%3Dmz_introspection"
   queries:
-  - name: "source_envelope_state_bytes"
-    help: "Count of messages for each source"
+  - name: "cluster_replica_usage"
+    help: "Cluster replica metrics"
     labels:
-      - "source_name"
-      - "source_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "source_envelope_state_bytes"
-    query:  |
-            SELECT
-              SUM(SS.envelope_state_bytes) as source_envelope_state_bytes,
-              S.name as source_name,
-              S.type as source_type,
-              S.cluster_id,
-              C.name as cluster_name
-            FROM mz_internal.mz_source_statistics SS
-            JOIN mz_catalog.mz_sources S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY S.name, S.type, S.cluster_id, cluster_name;
-  - name: "source_envelope_state_count"
-    help: "Count of messages for each source"
-    labels:
-      - "source_name"
-      - "source_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "source_envelope_state_count"
-    query:  |
-            SELECT
-              SUM(SS.envelope_state_count) as source_envelope_state_count,
-              S.name as source_name,
-              S.type as source_type,
-              S.cluster_id,
-              C.name as cluster_name
-            FROM mz_internal.mz_source_statistics SS
-            JOIN mz_catalog.mz_sources S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY S.name, S.type, S.cluster_id, cluster_name;
-  - name: "source_messages_received"
-    help: "Count of messages for each source"
-    labels:
-      - "source_name"
-      - "source_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "messages_received"
-    query:  |
-            SELECT
-              SUM(messages_received) as messages_received,
-              S.name as source_name,
-              S.type as source_type,
-              S.cluster_id,
-              C.name as cluster_name
-            FROM mz_internal.mz_source_statistics SS
-            JOIN mz_catalog.mz_sources S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY S.name, S.type, S.cluster_id, cluster_name;
-  - name: "source_bytes_received"
-    help: "Volume of messages for each source"
-    labels:
-      - "source_name"
-      - "source_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "bytes_received"
-    query:  |
-            SELECT
-              SUM(bytes_received) as bytes_received,
-              S.name as source_name,
-              S.type as source_type,
-              S.cluster_id,
-              C.name as cluster_name
-            FROM mz_internal.mz_source_statistics SS
-            JOIN mz_catalog.mz_sources S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY S.name, S.type, S.cluster_id, cluster_name;
-  - name: "sink_messages_commited"
-    help: "Count of messages for each sink"
-    labels:
-      - "sink_name"
-      - "sink_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "messages_committed"
-    query:  |
-            SELECT
-              SUM(messages_committed) as messages_committed,
-              S.name as sink_name,
-              S.type as sink_type,
-              S.cluster_id,
-              C.name as cluster_name
-            FROM mz_internal.mz_sink_statistics SS
-            JOIN mz_catalog.mz_sinks S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY sink_name, sink_type, cluster_id, cluster_name;
-  - name: "sink_bytes_committed"
-    help: "Volume of messages for each sink"
-    labels:
-      - "sink_name"
-      - "sink_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "bytes_committed"
-    query:  |
-            SELECT
-              SUM(bytes_committed) as bytes_committed,
-              S.name as sink_name,
-              S.type as sink_type,
-              S.cluster_id,
-              C.name as cluster_name
-            FROM mz_internal.mz_sink_statistics SS
-            JOIN mz_catalog.mz_sinks S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY sink_name, sink_type, cluster_id, cluster_name;
-  - name: "cluster_replica_cpu_usage"
-    help: "Cluster's replica CPU usage"
-    labels:
-      - "cluster_name"
       - "replica_id"
       - "cluster_id"
+      - "cluster_name"
       - "replica_name"
-      - "type"
+      - "cluster_type"
+      - "replica_status_label"
+      - "not_ready_reason"
     values:
       - "cpu_percent"
-    query:  |
-            SELECT
-              U.replica_id,
-              R.cluster_id,
-              C.name as cluster_name,
-              R.name as replica_name,
-              U.cpu_percent,
-              CASE
-                WHEN S.cluster_id IS NOT NULL THEN 'source'
-                WHEN SK.cluster_id IS NOT NULL THEN 'sink'
-                ELSE 'compute'
-              END AS type
-            FROM mz_internal.mz_cluster_replica_utilization U
-            JOIN mz_catalog.mz_cluster_replicas R ON (U.replica_id = R.id)
-            JOIN mz_catalog.mz_clusters C ON (R.cluster_id = C.id)
-            LEFT JOIN mz_catalog.mz_sources S ON (C.id = S.cluster_id)
-            LEFT JOIN mz_catalog.mz_sinks SK ON (C.id = SK.cluster_id);
-  - name: "cluster_replica_memory_usage"
-    help: "Cluster's replica memory usage"
-    labels:
-      - "cluster_name"
-      - "replica_name"
-      - "replica_id"
-      - "cluster_id"
-      - "type"
-    values:
       - "memory_percent"
+      - "credits_per_hour"
+      - "replica_status"
     query:  |
             SELECT
-              U.replica_id,
+              DISTINCT(U.replica_id),
               R.cluster_id,
               C.name as cluster_name,
               R.name as replica_name,
-              U.memory_percent,
+              RST.status as replica_status_label,
+              COALESCE(RST.reason, '') as not_ready_reason,
+              U.cpu_percent::float,
+              U.memory_percent::float,
+              RS.credits_per_hour::float,
+              CASE RST.status
+                WHEN 'ready' THEN 1
+                ELSE 0
+              END AS replica_status,
               CASE
                 WHEN S.cluster_id IS NOT NULL THEN 'source'
                 WHEN SK.cluster_id IS NOT NULL THEN 'sink'
                 ELSE 'compute'
-              END AS type
+              END AS cluster_type
             FROM mz_internal.mz_cluster_replica_utilization U
             JOIN mz_catalog.mz_cluster_replicas R ON (U.replica_id = R.id)
             JOIN mz_catalog.mz_clusters C ON (R.cluster_id = C.id)
+            JOIN mz_internal.mz_cluster_replica_sizes RS ON (R.size = RS.size)
+            JOIN mz_internal.mz_cluster_replica_statuses RST ON (RST.replica_id = R.id)
             LEFT JOIN mz_catalog.mz_sources S ON (C.id = S.cluster_id)
             LEFT JOIN mz_catalog.mz_sinks SK ON (C.id = SK.cluster_id);
-  - name: "source_status"
-    help: "Status for each source"
+  - name: "sink_statistics"
+    help: "Sink statistics"
     labels:
-      - "source_id"
-      - "source_name"
-      - "source_type"
-      - "source_status_label"
-    values:
-      - "source_status"
-    query:  |
-            SELECT
-              id as source_id,
-              name as source_name,
-              type as source_type,
-              status as source_status_label,
-              CASE status
-                WHEN 'created' THEN 0
-                WHEN 'starting' THEN 1
-                WHEN 'running' THEN 2
-                WHEN 'stalled' THEN 3
-                WHEN 'failed' THEN 4
-                WHEN 'dropped' THEN 5
-                ELSE 6
-              END AS source_status
-            FROM mz_internal.mz_source_statuses;
-  - name: "sink_status"
-    help: "Status for each sink"
-    labels:
-      - "sink_id"
       - "sink_name"
       - "sink_type"
+      - "cluster_id"
+      - "cluster_name"
       - "sink_status_label"
     values:
-      - "sink_status"
-    query:  |
+      - "messages_committed"
+      - "bytes_committed"
+      - "sink_status_counter"
+    query: |
             SELECT
-              id as sink_id,
-              name as sink_name,
-              type as sink_type,
+              S.name as sink_name,
+              S.type as sink_type,
+              S.cluster_id as cluster_id,
+              C.name as cluster_name,
               status as sink_status_label,
-              CASE status
-                WHEN 'created' THEN 0
-                WHEN 'starting' THEN 1
-                WHEN 'running' THEN 2
-                WHEN 'stalled' THEN 3
-                WHEN 'failed' THEN 4
-                WHEN 'dropped' THEN 5
-                ELSE 6
-              END AS sink_status
-            FROM mz_internal.mz_sink_statuses;
+              1 AS sink_status_counter,
+              SUM(messages_committed) as messages_committed,
+              SUM(bytes_committed) as bytes_committed
+            FROM mz_internal.mz_sink_statistics SS
+            JOIN mz_catalog.mz_sinks S ON (SS.id = S.id)
+            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
+            JOIN mz_internal.mz_sink_statuses ST ON (S.id = ST.id)
+            GROUP BY sink_name, sink_type, cluster_id, cluster_name, sink_status_label, sink_status_counter;
+  - name: "source_statistics"
+    help: "Source statistics"
+    labels:
+      - "source_name"
+      - "source_type"
+      - "cluster_id"
+      - "cluster_name"
+      - "source_status_label"
+    values:
+      - "snapshot_committed"
+      - "envelope_state_bytes"
+      - "envelope_state_count"
+      - "messages_received"
+      - "bytes_received"
+      - "source_status_counter"
+    query: |
+            SELECT
+              S.name as source_name,
+              S.type as source_type,
+              S.cluster_id,
+              C.name as cluster_name,
+              status as source_status_label,
+              1 AS source_status_counter,
+              bool_and(snapshot_committed)::int::float as snapshot_committed,
+              SUM(SS.envelope_state_bytes) as envelope_state_bytes,
+              SUM(SS.envelope_state_count) as envelope_state_count,
+              SUM(messages_received) as messages_received,
+              SUM(bytes_received) as bytes_received
+            FROM mz_internal.mz_source_statistics SS
+            JOIN mz_catalog.mz_sources S ON (SS.id = S.id)
+            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
+            JOIN mz_internal.mz_source_statuses ST ON (S.id = ST.id)
+            GROUP BY S.name, S.type, S.cluster_id, cluster_name, source_status_label, source_status_counter, snapshot_committed;
+- name: "materialize"
+  interval: '1h'
+  connections:
+  - "postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/materialize?options=--cluster%3Dmz_introspection"
+  queries:
   - name: "storage_usage"
-    help: "Storage Usage"
+    help: "Storage usage"
     labels:
       - "object_name"
       - "object_type"
       - "object_id"
     values:
       - "size_bytes"
-    query:  |
+    query: |
             WITH last_measure AS (
               SELECT
                 object_id,
@@ -246,95 +130,12 @@ jobs:
               GROUP BY object_id
             )
             SELECT
+              DISTINCT(id) as object_id,
               name as object_name,
               type as object_type,
-              id as object_id,
-              SUM(size_bytes) AS size_bytes
-            FROM mz_storage_usage U
-            JOIN mz_objects O ON (U.object_id = O.id)
-            JOIN last_measure L ON (L.timestamp = U.collection_timestamp)
-            WHERE owner_id NOT LIKE 's%'
-            GROUP BY name, type, id;
-  - name: "source_snapshot"
-    help: "Source snapshot information"
-    labels:
-      - "source_name"
-      - "source_id"
-      - "source_type"
-      - "cluster_id"
-      - "cluster_name"
-    values:
-      - "snapshot_committed"
-    query:  |
-            SELECT
-              S.id as source_id,
-              S.name as source_name,
-              S.type as source_type,
-              C.id as cluster_id,
-              C.name as cluster_name,
-              bool_and(snapshot_committed)::int as snapshot_committed
-            FROM mz_internal.mz_source_statistics SS
-            JOIN mz_sources S ON (SS.id = S.id)
-            JOIN mz_catalog.mz_clusters C ON (S.cluster_id = C.id)
-            GROUP BY S.id, S.name, S.type, C.id, C.name;
-  - name: "object_counts"
-    help: "Count per type object created"
-    labels:
-      - "type"
-    values:
-      - "count"
-    query:  |
-            SELECT
-              type,
-              count(1) as count
-            FROM mz_objects
-            WHERE type IN (
-              'table',
-              'view',
-              'materialized-view',
-              'sink',
-              'index',
-              'connection',
-              'secret',
-              'source'
-            ) AND owner_id NOT LIKE 's%'
-            GROUP BY type;
-  - name: "cluster_replica_credits_usage"
-    help: "Cluster's replica credit usage"
-    labels:
-      - "cluster_name"
-      - "replica_id"
-      - "cluster_id"
-      - "replica_name"
-    values:
-      - "credits_per_hour"
-    query:  |
-            SELECT
-                C.name as cluster_name,
-                R.id as replica_id,
-                R.name as replica_name,
-                C.id as cluster_id,
-                S.credits_per_hour
-              FROM mz_cluster_replicas R
-              JOIN mz_internal.mz_cluster_replica_sizes S ON (R.size = S.size)
-              JOIN mz_clusters C ON (R.cluster_id = C.id);
-  # - name: "cluster_replica_statuses"
-  #   help: "Cluster's replica status"
-  #   labels:
-  #     - "cluster_name"
-  #     - "replica_id"
-  #     - "cluster_id"
-  #     - "replica_name"
-  #   values:
-  #     - "credits_per_hour"
-  #   query:  |
-  #           SELECT
-  #               C.name as cluster_name,
-  #               R.id as replica_id,
-  #               R.name as replica_name,
-  #               C.id as cluster_id,
-  #               S.credits_per_hour
-  #             FROM mz_cluster_replicas R
-  #             JOIN mz_internal.mz_cluster_replica_sizes S ON (R.size = S.size)
-  #             JOIN mz_clusters C ON (R.cluster_id = C.id);
-  # Add cluster restarts
+              size_bytes
+            FROM mz_storage_usage U, mz_objects O, last_measure L
+            WHERE O.id = U.object_id
+            AND O.id = L.object_id
+            AND U.collection_timestamp = L.timestamp
+            AND id NOT LIKE 's%';

--- a/integrations/prometheus-sql-exporter/grafana/dashboards/dashboard.json
+++ b/integrations/prometheus-sql-exporter/grafana/dashboards/dashboard.json
@@ -22,258 +22,1094 @@
   "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
     {
+      "collapsed": true,
       "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": false,
-          "expr": "sql_cluster_replica_cpu_usage{}",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{ cluster_name }}",
-          "refId": "A"
-        }
-      ],
-      "title": "CPU Usage per Cluster Replica",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": false,
-          "expr": "sql_cluster_replica_memory_usage{}",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{ cluster_name }}",
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Usage per Cluster Replica",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 0
       },
-      "id": 5,
-      "options": {
-        "displayLabels": [],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "values": [
-            "percent",
-            "value"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
+      "id": 16,
+      "panels": [
         {
-          "exemplar": true,
-          "expr": "sql_storage_usage{}",
-          "interval": "",
-          "legendFormat": "{{ object_name }} - {{object_type}}",
-          "refId": "A"
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "sql_cluster_replica_usage{cluster_type=\"compute\",col=\"cpu_percent\"}",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{ cluster_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Usage per Computing Cluster",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "sql_cluster_replica_usage{cluster_type=\"compute\",col=\"memory_percent\"}",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{ cluster_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage per Computing Cluster",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 10
+          },
+          "id": 5,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "values": [
+                "percent",
+                "value"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_storage_usage{col=\"size_bytes\",object_type=~\"materialized-view|table\"}",
+              "interval": "",
+              "legendFormat": "{{ object_name }} - {{object_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Storage Usage per Object",
+          "type": "piechart"
         }
       ],
-      "title": "Storage Usage per Object",
-      "type": "piechart"
+      "title": "Resources Overview",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 18,
+      "panels": [
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 23,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "{cluster_type=\"source\",col=\"cpu_percent\"}",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{ cluster_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Usage per Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "{cluster_type=\"source\",col=\"memory_percent\"}",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{ cluster_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage per Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
+          "id": 25,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "values": [
+                "percent",
+                "value"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_storage_usage{col=\"size_bytes\",object_type=\"source\"}",
+              "interval": "",
+              "legendFormat": "{{ object_name }} - {{object_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Storage Usage per Object",
+          "type": "piechart"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_source_statistics{col=\"bytes_received\"}",
+              "interval": "",
+              "legendFormat": "{{ source_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes Received per Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_source_statistics{col=\"messages_received\"}",
+              "interval": "",
+              "legendFormat": "{{ source_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Messages Count per Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 26,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_source_statistics{col=\"envelope_state_bytes\"}",
+              "interval": "",
+              "legendFormat": "{{ source_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Envelope State Size per Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 27,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_source_statistics{col=\"envelope_state_count\"}",
+              "interval": "",
+              "legendFormat": "{{ source_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Envelope State Count per Source",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Sources",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 20,
+      "panels": [
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 30,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.2.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "{cluster_type=~\"sink|source\",col=\"credits_per_hour\"}",
+              "interval": "",
+              "legendFormat": "{{cluster_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Consumption Rate per Hour",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "mode": "reduceRow",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": true
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_cluster_replica_usage{cluster_type=\"compute\",col=\"credits_per_hour\"}",
+              "interval": "",
+              "legendFormat": "{{cluster_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Per Computing Cluster",
+          "type": "piechart"
+        },
+        {
+          "datasource": null,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 33,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sql_cluster_replica_usage{cluster_type=~\"sink|source\",col=\"credits_per_hour\"}",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{cluster_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Per Source and Sink",
+          "type": "piechart"
+        }
+      ],
+      "title": "Credit Consumption",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Sinks",
+      "type": "row"
     },
     {
       "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
-            "fillOpacity": 70,
-            "lineWidth": 1
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -282,53 +1118,134 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
-                "value": 3
-              },
-              {
                 "color": "red",
-                "value": 4
-              },
-              {
-                "color": "text",
-                "value": 5
+                "value": 80
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 4
       },
-      "id": 7,
+      "id": 31,
       "options": {
-        "colWidth": 0.9,
         "legend": {
-          "displayMode": "hidden",
+          "calcs": [],
+          "displayMode": "table",
           "placement": "bottom"
         },
-        "rowHeight": 0.9,
-        "showValue": "auto",
         "tooltip": {
           "mode": "single"
         }
       },
-      "pluginVersion": "8.2.0",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "sql_source_status{}",
+          "exemplar": false,
+          "expr": "sql_cluster_replica_usage{cluster_type=\"sink\",col=\"cpu_percent\"}",
+          "format": "time_series",
+          "instant": false,
           "interval": "",
-          "legendFormat": "{{ source_name }}",
+          "legendFormat": "{{ cluster_name }}",
           "refId": "A"
         }
       ],
-      "title": "Source Status",
-      "type": "status-history"
+      "title": "CPU Usage per Sink",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sql_cluster_replica_usage{cluster_type=\"sink\",col=\"memory_percent\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{ cluster_name }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage per Sink",
+      "type": "timeseries"
     },
     {
       "datasource": null,
@@ -348,18 +1265,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 3
-              },
-              {
-                "color": "red",
-                "value": 4
-              },
-              {
-                "color": "text",
-                "value": 5
               }
             ]
           }
@@ -368,9 +1273,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
+        "w": 24,
+        "x": 0,
+        "y": 13
       },
       "id": 8,
       "options": {
@@ -389,7 +1294,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sql_sink_status{}",
+          "expr": "sql_sink_statistics{col=\"sink_status_counter\"}",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ sink_name }}",
@@ -441,14 +1346,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -456,252 +1357,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sql_source_bytes_received{}",
-          "interval": "",
-          "legendFormat": "{{ source_name }}",
-          "refId": "A"
-        }
-      ],
-      "title": "Bytes Received per Source",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sql_sink_bytes_committed{}",
-          "interval": "",
-          "legendFormat": "{{ source_name }}",
-          "refId": "A"
-        }
-      ],
-      "title": "Bytes Committed per Sink",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 32
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "sql_source_messages_received{}",
-          "interval": "",
-          "legendFormat": "{{ source_name }}",
-          "refId": "A"
-        }
-      ],
-      "title": "Messages Count per Source",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 32
+        "y": 21
       },
       "id": 13,
       "options": {
@@ -717,16 +1373,99 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sql_sink_bytes_committed{}",
+          "expr": "sql_sink_statistics{col=\"messages_committed\"}",
           "interval": "",
-          "legendFormat": "{{ cluster_name }}",
+          "legendFormat": "{{ sink_name }}",
           "refId": "A"
         }
       ],
       "title": "Messages Committed per Sink",
       "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sql_sink_statistics{col=\"bytes_committed\"}",
+          "interval": "",
+          "legendFormat": "{{ sink_name }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bytes Committed per Sink",
+      "type": "timeseries"
     }
   ],
+  "refresh": "",
   "schemaVersion": 31,
   "style": "dark",
   "tags": [],
@@ -741,5 +1480,5 @@
   "timezone": "",
   "title": "Materialize Dashboard",
   "uid": "XxPvy3PVk",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This PR updates the Grafana integration guide with newer queries and a new template. The queries are the same ones used in the Datadog integration guide and I tried to match the same dashboard template.