### PR TITLE
Integrations: fix credit consumption for Grafana dashboard

### DIFF
--- a/integrations/prometheus-sql-exporter/grafana/dashboards/dashboard.json
+++ b/integrations/prometheus-sql-exporter/grafana/dashboards/dashboard.json
@@ -920,7 +920,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "{cluster_type=~\"sink|source\",col=\"credits_per_hour\"}",
+              "expr": "{col=\"credits_per_hour\"}",
               "interval": "",
               "legendFormat": "{{cluster_name}}",
               "refId": "A"


### PR DESCRIPTION
This PR fixes how the credit consumption is displayed in the Grafana dashboard template. It was wrongly segmented by sources and sinks.