### PR TITLE
integrations/grafana/cloud: rename agent file and remove dependencies

### DIFF
--- a/integrations/grafana/cloud/agent.yaml
+++ b/integrations/grafana/cloud/agent.yaml
@@ -6,7 +6,7 @@ metrics:
     scrape_configs:
       - job_name: node
         static_configs:
-        - targets: ['localhost:9237']
+        - targets: ['sql-exporter:9237']
     remote_write:
       - url: <REMOTE_WRITE_URL>
         basic_auth:

--- a/integrations/grafana/cloud/docker-compose.yaml
+++ b/integrations/grafana/cloud/docker-compose.yaml
@@ -1,11 +1,10 @@
 version: '2'
 
 services:
-   agent:
-    profiles: [agent]
+  agent:
     image: grafana/agent:latest
     volumes:
-      - ./agent/config:/etc/agent-config
+      - ./agent.yaml:/etc/agent-config/agent.yaml
     entrypoint:
       - /bin/grafana-agent
       - -server.http.address=0.0.0.0:12345
@@ -16,11 +15,6 @@ services:
       - -config.enable-read-api
     ports:
       - "12345:12345"
-    depends_on:
-      - cortex
-      - loki
-      - tempo
-
   sql-exporter:
     image: justwatch/sql_exporter:latest
     ports:


### PR DESCRIPTION
This PR removes wrong dependencies from the Grafana agent, and renames the file the same way the Grafana guide does.