### PR TITLE
integrations/datadog: exclude go metrics

### DIFF
--- a/integrations/datadog/datadog/conf.d/openmetrics.yaml
+++ b/integrations/datadog/datadog/conf.d/openmetrics.yaml
@@ -116,7 +116,7 @@ instances:
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$
     #
-    # exclude_metrics: []
+    exclude_metrics: [^go.*$]
 
     ## @param exclude_metrics_by_labels - mapping - optional
     ## A mapping of labels where metrics with matching label name and values are ignored. To match


### PR DESCRIPTION
This PR removes the go metrics from the Datadog integration guide. The Datadog agent has a limit of 2000 metrics. Consuming the go metrics from the SQL-exporter consumes a lot of them, while they are not explicitly requested by the user.