### PR TITLE
integrations/datadog: static version

### DIFF
--- a/integrations/datadog/datadog/Dockerfile
+++ b/integrations/datadog/datadog/Dockerfile
@@ -1,2 +1,2 @@
-FROM gcr.io/datadoghq/agent:latest
+FROM gcr.io/datadoghq/agent:7.44.0
 ADD conf.d/openmetrics.yaml /etc/datadog-agent/conf.d/openmetrics.yaml


### PR DESCRIPTION
This PR sets a static version for the datadog agent. 